### PR TITLE
Fixed inputstreams support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,12 @@
             <artifactId>httpmime</artifactId>
             <version>${httpclient.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     	<java.version>1.8</java.version>
         <httpclient.version>4.5.1</httpclient.version>
+        <guava.version>18.0</guava.version>
     </properties>
 
     <dependencies>
@@ -32,7 +33,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>${guava.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/cloud/benchflow/faban/client/FabanClient.java
+++ b/src/main/java/cloud/benchflow/faban/client/FabanClient.java
@@ -19,9 +19,9 @@ public class FabanClient extends Configurable<FabanClientConfigImpl> {
 
     private FabanClientConfig fabanConfig = new FabanClientDefaultConfig();
 
-    public DeployStatus deploy(InputStream jarFile) throws FabanClientException {
+    public DeployStatus deploy(InputStream jarFile, String driverName) throws FabanClientException {
 
-        DeployConfig config = new DeployConfig(jarFile);
+        DeployConfig config = new DeployConfig(jarFile, driverName);
         DeployCommand deploy = new DeployCommand().withConfig(config);
 
         try {
@@ -41,7 +41,7 @@ public class FabanClient extends Configurable<FabanClientConfigImpl> {
 
         try(FileInputStream fin = new FileInputStream(jarFile)) {
 
-            return deploy(fin);
+            return deploy(fin, jarFile.getName());
 
         } catch (FileNotFoundException e) {
             throw new JarFileNotFoundException("The specified jar file ( " +
@@ -54,12 +54,12 @@ public class FabanClient extends Configurable<FabanClientConfigImpl> {
 
     }
 
-    public <R extends DeployStatus, T> T deploy(InputStream jarFile, Function<R, T> handler) throws FabanClientException {
-        return this.deploy(jarFile).handle(handler);
+    public <R extends DeployStatus, T> T deploy(InputStream jarFile, String driverName, Function<R, T> handler) throws FabanClientException {
+        return this.deploy(jarFile, driverName).handle(handler);
     }
 
-    public <R extends DeployStatus> void deploy(InputStream jarFile, Consumer<R> handler) throws FabanClientException {
-        this.deploy(jarFile).handle(handler);
+    public <R extends DeployStatus> void deploy(InputStream jarFile, String driverName, Consumer<R> handler) throws FabanClientException {
+        this.deploy(jarFile, driverName).handle(handler);
     }
 
     /**

--- a/src/main/java/cloud/benchflow/faban/client/FabanClient.java
+++ b/src/main/java/cloud/benchflow/faban/client/FabanClient.java
@@ -69,7 +69,7 @@ public class FabanClient extends Configurable<FabanClientConfigImpl> {
      * @param <T> the arbitrary return type
      * @return an object of type {@code <T>}
      */
-    public <R extends DeployStatus, T> T deploy(File jarFile, Function<R, T> handler) throws FabanClientException, JarFileNotFoundException {
+    public <R extends DeployStatus, T> T deploy(File jarFile, Function<R, T> handler) throws JarFileNotFoundException, FabanClientException  {
         return this.deploy(jarFile).handle(handler);
     }
 
@@ -80,7 +80,7 @@ public class FabanClient extends Configurable<FabanClientConfigImpl> {
      * @param <R> the type of the handler input (has to extend {@link DeployStatus})
      * @throws FabanClientException
      */
-    public <R extends DeployStatus> void deploy(File jarFile, Consumer<R> handler) throws FabanClientException, JarFileNotFoundException {
+    public <R extends DeployStatus> void deploy(File jarFile, Consumer<R> handler) throws JarFileNotFoundException, FabanClientException  {
         this.deploy(jarFile).handle(handler);
     }
 

--- a/src/main/java/cloud/benchflow/faban/client/commands/Command.java
+++ b/src/main/java/cloud/benchflow/faban/client/commands/Command.java
@@ -2,7 +2,7 @@ package cloud.benchflow.faban.client.commands;
 
 import cloud.benchflow.faban.client.configurations.FabanClientConfig;
 import cloud.benchflow.faban.client.responses.Response;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
 
 /**
  * @author Simone D'Avico <simonedavico@gmail.com>
@@ -12,7 +12,7 @@ import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 public interface Command<T extends Response> {
 
     default T exec(FabanClientConfig fabanConfig) throws Exception {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
 }

--- a/src/main/java/cloud/benchflow/faban/client/commands/DeployCommand.java
+++ b/src/main/java/cloud/benchflow/faban/client/commands/DeployCommand.java
@@ -5,12 +5,15 @@ import cloud.benchflow.faban.client.configurations.FabanClientConfig;
 import cloud.benchflow.faban.client.responses.DeployStatus;
 import cloud.benchflow.faban.client.configurations.Configurable;
 import cloud.benchflow.faban.client.exceptions.MalformedURIException;
+import com.google.common.io.ByteStreams;
 import org.apache.http.HttpEntity;
 
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.entity.mime.content.InputStreamBody;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 
@@ -52,11 +55,15 @@ public class DeployCommand extends Configurable<DeployConfig> implements Command
                                 .setPath(DEPLOY_URL)
                                 .build();
             HttpPost post = new HttpPost(deployURL);
+
+            byte[] boh = ByteStreams.toByteArray(jarFile);
+
             HttpEntity multipartEntity = MultipartEntityBuilder.create()
                                   .addTextBody("user", fabanConfig.getUser())
                                   .addTextBody("password", fabanConfig.getPassword())
                                   .addTextBody("clearconfig", clearConfig.toString())
-                                  .addBinaryBody("jarfile", jarFile)
+                                  .addBinaryBody("jarfile", ByteStreams.toByteArray(jarFile),
+                                                 ContentType.DEFAULT_BINARY, this.config.getDriverName())
                                   .build();
 
             post.setEntity(multipartEntity);

--- a/src/main/java/cloud/benchflow/faban/client/commands/SubmitCommand.java
+++ b/src/main/java/cloud/benchflow/faban/client/commands/SubmitCommand.java
@@ -7,11 +7,13 @@ import cloud.benchflow.faban.client.exceptions.EmptyHarnessResponseException;
 import cloud.benchflow.faban.client.configurations.Configurable;
 import cloud.benchflow.faban.client.exceptions.MalformedURIException;
 import cloud.benchflow.faban.client.responses.RunId;
+import com.google.common.io.ByteStreams;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -55,7 +57,8 @@ public class SubmitCommand extends Configurable<SubmitConfig> implements Command
             HttpEntity multipartEntity = MultipartEntityBuilder.create()
                                     .addTextBody("sun", fabanConfig.getUser())
                                     .addTextBody("sp", fabanConfig.getPassword())
-                                    .addBinaryBody("configfile", configFile)
+                                    .addBinaryBody("configfile", ByteStreams.toByteArray(configFile),
+                                                   ContentType.DEFAULT_BINARY, "run.xml")
                                     .build();
 
             post.setEntity(multipartEntity);

--- a/src/main/java/cloud/benchflow/faban/client/configurations/DeployConfig.java
+++ b/src/main/java/cloud/benchflow/faban/client/configurations/DeployConfig.java
@@ -11,14 +11,16 @@ public class DeployConfig implements Config {
 
     //private File jarFile;
     private InputStream jarFile;
+    private String driverName;
     private boolean clearConfig;
 
-    public DeployConfig(InputStream jarFile) {
-        this(jarFile, true);
+    public DeployConfig(InputStream jarFile, String driverName) {
+        this(jarFile, driverName, true);
     }
 
-    public DeployConfig(InputStream jarFile, boolean clearConfig) {
+    public DeployConfig(InputStream jarFile, String driverName, boolean clearConfig) {
         this.jarFile = jarFile;
+        this.driverName = driverName;
         this.clearConfig = clearConfig;
     }
 
@@ -30,5 +32,5 @@ public class DeployConfig implements Config {
         return clearConfig;
     }
 
-
+    public String getDriverName() { return driverName; }
 }

--- a/src/test/java/cloud/benchflow/faban/test/client/Main.java
+++ b/src/test/java/cloud/benchflow/faban/test/client/Main.java
@@ -4,11 +4,10 @@ import cloud.benchflow.faban.client.FabanClient;
 import cloud.benchflow.faban.client.exceptions.JarFileNotFoundException;
 import cloud.benchflow.faban.client.responses.DeployStatus;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.function.Consumer;
+
 
 /**
  * @author Simone D'Avico <simonedavico@gmail.com>


### PR DESCRIPTION
The inpustream is now read into an array of bytes before being attached to the request, in order to avoid internal server errors on the faban harness side. In order to do this without too much code overhead, I added Guava as a dependency and exploited Guava's `ByteStreams` class.