### PR TITLE
Changed library to send files with Content-Type "application/octet-stream"

### DIFF
--- a/src/main/java/cloud/benchflow/faban/client/commands/DeployCommand.java
+++ b/src/main/java/cloud/benchflow/faban/client/commands/DeployCommand.java
@@ -13,7 +13,6 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
-import org.apache.http.entity.mime.content.InputStreamBody;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 
@@ -21,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+
 
 
 /**
@@ -56,14 +56,16 @@ public class DeployCommand extends Configurable<DeployConfig> implements Command
                                 .build();
             HttpPost post = new HttpPost(deployURL);
 
-            byte[] boh = ByteStreams.toByteArray(jarFile);
-
             HttpEntity multipartEntity = MultipartEntityBuilder.create()
                                   .addTextBody("user", fabanConfig.getUser())
                                   .addTextBody("password", fabanConfig.getPassword())
                                   .addTextBody("clearconfig", clearConfig.toString())
                                   .addBinaryBody("jarfile", ByteStreams.toByteArray(jarFile),
-                                                 ContentType.DEFAULT_BINARY, this.config.getDriverName())
+                                                 //ContentType.create("application/java-archive"),
+                                                 //ContentType.DEFAULT_BINARY,
+                                                ContentType.create("application/octet-stream"),
+                                                 //"gobenchmark.jar")
+                                                 this.config.getDriverName())
                                   .build();
 
             post.setEntity(multipartEntity);

--- a/src/main/java/cloud/benchflow/faban/client/commands/SubmitCommand.java
+++ b/src/main/java/cloud/benchflow/faban/client/commands/SubmitCommand.java
@@ -57,8 +57,11 @@ public class SubmitCommand extends Configurable<SubmitConfig> implements Command
             HttpEntity multipartEntity = MultipartEntityBuilder.create()
                                     .addTextBody("sun", fabanConfig.getUser())
                                     .addTextBody("sp", fabanConfig.getPassword())
-                                    .addBinaryBody("configfile", ByteStreams.toByteArray(configFile),
-                                                   ContentType.DEFAULT_BINARY, "run.xml")
+                                    .addBinaryBody("configfile",
+                                                   ByteStreams.toByteArray(configFile),
+                                                   //ContentType.DEFAULT_BINARY,
+                                                   ContentType.create("application/octet-stream"),
+                                                   "run.xml")
                                     .build();
 
             post.setEntity(multipartEntity);

--- a/src/test/java/cloud/benchflow/faban/test/client/Main.java
+++ b/src/test/java/cloud/benchflow/faban/test/client/Main.java
@@ -1,10 +1,14 @@
 package cloud.benchflow.faban.test.client;
 
 import cloud.benchflow.faban.client.FabanClient;
+import cloud.benchflow.faban.client.configurations.FabanClientConfigImpl;
 import cloud.benchflow.faban.client.exceptions.JarFileNotFoundException;
 import cloud.benchflow.faban.client.responses.DeployStatus;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -16,11 +20,12 @@ import java.nio.file.Paths;
  */
 public class Main {
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, URISyntaxException {
 
         //get an instance of faban client
-        FabanClient client = new FabanClient();
+        FabanClient client = new FabanClient().withConfig(new FabanClientConfigImpl("deployer","adminadmin",new URI("http://195.176.181.55:9980")));
         Path bm = Paths.get("./src/test/resources/foofoofoo.jar");
+
         try {
             client.deploy(bm.toFile()).handle((DeployStatus s) -> System.out.println(s.getCode()));
         } catch (JarFileNotFoundException e) {


### PR DESCRIPTION
Changed because Faban wasn’t reacting well to `ContentType.DEFAULT_BINARY`.