### PR TITLE
Changes deploy command to send a File instead of an InputStream

### DIFF
--- a/src/main/java/cloud/benchflow/faban/client/FabanClient.java
+++ b/src/main/java/cloud/benchflow/faban/client/FabanClient.java
@@ -23,30 +23,21 @@ public class FabanClient extends Configurable<FabanClientConfig> {
         return (config == null) ? defaultConfig : config;
     }
 
-    public DeployStatus deploy(InputStream jarFile, String driverName) throws FabanClientException {
-
-        DeployConfig deployConfig = new DeployConfig(jarFile, driverName);
-        DeployCommand deploy = new DeployCommand().withConfig(deployConfig);
-        FabanClientConfig fabanConfig = chooseConfig();
-
-        try {
-            return deploy.exec(fabanConfig);
-        } catch (IOException e) {
-            throw new FabanClientException("An unknow error occurred while processing the driver to deploy. " +
-                                           "Please try again.", e);
-        }
-
-    }
-
     /**
      * @param jarFile the benchmark to be deployed on the faban harness
      * @return a response enclosing the status of the operation
      */
     public DeployStatus deploy(File jarFile) throws FabanClientException, JarFileNotFoundException {
 
+        String benchmarkName = jarFile.getName();
+        DeployConfig deployConfig = new DeployConfig(jarFile, benchmarkName);
+        DeployCommand deploy = new DeployCommand().withConfig(deployConfig);
+        FabanClientConfig fabanConfig = chooseConfig();
+
         try(FileInputStream fin = new FileInputStream(jarFile)) {
 
-            return deploy(fin, jarFile.getName());
+            return deploy.exec(fabanConfig);
+            //return deploy(fin, jarFile.getName());
 
         } catch (FileNotFoundException e) {
             throw new JarFileNotFoundException("The specified jar file ( " +
@@ -59,12 +50,12 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
     }
 
-    public <R extends DeployStatus, T> T deploy(InputStream jarFile, String driverName, Function<R, T> handler) throws FabanClientException {
-        return this.deploy(jarFile, driverName).handle(handler);
+    public <R extends DeployStatus, T> T deploy(File jarFile, String driverName, Function<R, T> handler) throws FabanClientException, JarFileNotFoundException {
+        return this.deploy(jarFile).handle(handler);
     }
 
-    public <R extends DeployStatus> void deploy(InputStream jarFile, String driverName, Consumer<R> handler) throws FabanClientException {
-        this.deploy(jarFile, driverName).handle(handler);
+    public <R extends DeployStatus> void deploy(File jarFile, String driverName, Consumer<R> handler) throws FabanClientException, JarFileNotFoundException {
+        this.deploy(jarFile).handle(handler);
     }
 
     /**

--- a/src/main/java/cloud/benchflow/faban/client/commands/DeployCommand.java
+++ b/src/main/java/cloud/benchflow/faban/client/commands/DeployCommand.java
@@ -51,6 +51,15 @@ public class DeployCommand extends Configurable<DeployConfig> implements Command
         return deploy(fabanConfig);
     }
 
+
+    /*  Since deploying a stream to Faban suddenly doesn’t work anymore, we
+        changed the API to deploy a File (which works as expected).
+
+        A stream would have been better because it wouldn’t have required to
+        have a file on the file system, reducing the IO of the components using
+        the library.
+        Nevertheless, this solution is good enough until we figure out how to
+        send a stream of data to Faban. */
     private DeployStatus deploy(FabanClientConfig fabanConfig) throws IOException {
 
         ResponseHandler<DeployStatus> dh = resp -> {

--- a/src/main/java/cloud/benchflow/faban/client/configurations/DeployConfig.java
+++ b/src/main/java/cloud/benchflow/faban/client/configurations/DeployConfig.java
@@ -1,5 +1,6 @@
 package cloud.benchflow.faban.client.configurations;
 
+import java.io.File;
 import java.io.InputStream;
 
 /**
@@ -9,22 +10,22 @@ import java.io.InputStream;
  */
 public class DeployConfig implements Config {
 
-    //private File jarFile;
-    private InputStream jarFile;
+    private File jarFile;
+//    private InputStream jarFile;
     private String driverName;
     private boolean clearConfig;
 
-    public DeployConfig(InputStream jarFile, String driverName) {
+    public DeployConfig(File jarFile, String driverName) {
         this(jarFile, driverName, true);
     }
 
-    public DeployConfig(InputStream jarFile, String driverName, boolean clearConfig) {
+    public DeployConfig(File jarFile, String driverName, boolean clearConfig) {
         this.jarFile = jarFile;
         this.driverName = driverName;
         this.clearConfig = clearConfig;
     }
 
-    public InputStream getJarFile() {
+    public File getJarFile() {
         return jarFile;
     }
 

--- a/src/test/java/cloud/benchflow/faban/test/client/Main.java
+++ b/src/test/java/cloud/benchflow/faban/test/client/Main.java
@@ -3,6 +3,7 @@ package cloud.benchflow.faban.test.client;
 import cloud.benchflow.faban.client.FabanClient;
 import cloud.benchflow.faban.client.configurations.FabanClientConfig;
 import cloud.benchflow.faban.client.configurations.FabanClientConfigImpl;
+import cloud.benchflow.faban.client.exceptions.ConfigFileNotFoundException;
 import cloud.benchflow.faban.client.exceptions.JarFileNotFoundException;
 import cloud.benchflow.faban.client.exceptions.RunIdNotFoundException;
 import cloud.benchflow.faban.client.responses.DeployStatus;
@@ -25,13 +26,15 @@ public class Main {
     public static void main(String[] args) throws IOException, URISyntaxException, RunIdNotFoundException {
 
         //get an instance of faban client
-        FabanClientConfig fcprova = new FabanClientConfigImpl("deployer","adminadmin",new URI("http://195.176.181.105:9980"));
+        FabanClientConfig fcprova = new FabanClientConfigImpl("deployer","adminadmin",new URI("http://localhost:9980"));
         FabanClient client = new FabanClient().withConfig(fcprova);
         Path bm = Paths.get("./src/test/resources/foofoofoo.jar");
+        Path configFile = Paths.get("./src/test/resources/");
 
         try {
             client.deploy(bm.toFile()).handle((DeployStatus s) -> System.out.println(s.getCode()));
-        } catch (JarFileNotFoundException e) {
+            client.submit("fooBenchmark", "fooBenchmark", Paths.get("").toFile());
+        } catch (JarFileNotFoundException | ConfigFileNotFoundException e) {
             e.printStackTrace();
         }
         //FabanClientConfigImpl config = new FabanClientConfigImpl("","",new URI("http://195.176.181.55:9980/"));


### PR DESCRIPTION
Since deploying a stream to Faban suddenly doesn’t work anymore, we
changed the API to deploy a File (which works as expected).

A stream would have been better because it wouldn’t have required to
have a file on the file system, reducing the IO of the components using
the library.
Nevertheless, this solution is good enough until we figure out how to
send a stream of data to Faban.

Fixes https://github.com/benchflow/faban-client/issues/10
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/benchflow/faban-client/pull/11?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/faban-client/pull/11'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>